### PR TITLE
Refactor book management and add new configurations

### DIFF
--- a/LibraryApp.Domain/Entities/Configurations/AdminConfiguration.cs
+++ b/LibraryApp.Domain/Entities/Configurations/AdminConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LibraryApp.Domain.Entities.Configurations;
+
+public class AdminConfiguration : BaseUserConfiguration<Admin>
+{
+    public override void Configure(EntityTypeBuilder<Admin> builder)
+    {
+        base.Configure(builder);
+    }
+}

--- a/LibraryApp.Domain/Entities/Configurations/BookConfiguration.cs
+++ b/LibraryApp.Domain/Entities/Configurations/BookConfiguration.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibraryApp.Domain.Entities.Configurations
+{
+    public class BookConfiguration:AuditableEntityConfiguration<Book>
+    {
+        public override void Configure(EntityTypeBuilder<Book> builder)
+        {
+            base.Configure(builder);
+            builder.Property(b => b.ISBN)
+                    .HasMaxLength(13)
+                    .IsRequired();
+
+            builder.Property(b => b.Title)
+                   .HasMaxLength(256)
+                   .IsRequired();
+
+            builder.Property(b => b.Description)
+                   .HasMaxLength(1024)
+                   .IsRequired(false);
+
+            builder.Property(b => b.Author)
+                   .HasMaxLength(256)
+                   .IsRequired();
+
+            builder.Property(b => b.PublicationYear)
+                   .IsRequired();
+
+
+            builder.HasOne(b => b.BookCategory)
+                   .WithMany(bc => bc.Books)
+                   .HasForeignKey(b => b.BookCategoryId);
+
+            builder.HasMany(b => b.BookCopies)
+                   .WithOne(bl => bl.Book)
+                   .HasForeignKey(bl => bl.BookId);
+        }
+    }
+}

--- a/LibraryApp.Domain/Entities/Configurations/BookCopyConfiguration.cs
+++ b/LibraryApp.Domain/Entities/Configurations/BookCopyConfiguration.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibraryApp.Domain.Entities.Configurations
+{
+    public class BookCopyConfiguration:AuditableEntityConfiguration<BookCopy>
+    {
+        public override void Configure(EntityTypeBuilder<BookCopy> builder)
+        {
+            base.Configure(builder);
+
+            builder.Property(bc => bc.CopyNumber)
+                                    .IsRequired();
+            builder.Property(bc=>bc.BookStatus)
+                                    .IsRequired();
+
+            builder.HasMany(bc => bc.BookLoans)
+                    .WithOne(bl => bl.BookCopy)
+                    .HasForeignKey(bl => bl.BookCopyId);
+
+            builder.HasOne(bc => bc.Book)
+                    .WithMany(b => b.BookCopies)
+                    .HasForeignKey(bc => bc.BookId);
+            
+        }
+    }
+}

--- a/LibraryApp.Domain/Entities/Configurations/BookLoanConfiguration.cs
+++ b/LibraryApp.Domain/Entities/Configurations/BookLoanConfiguration.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibraryApp.Domain.Entities.Configurations
+{
+    public class BookLoanConfiguration : AuditableEntityConfiguration<BookLoan>
+    {
+        public override void Configure(EntityTypeBuilder<BookLoan> builder)
+        {
+            base.Configure(builder);
+            builder.Property(bl=>bl.BorrowDate)
+                                    .IsRequired();
+            builder.Property(bl => bl.ReturnDate)
+                                    .IsRequired(false);
+
+            builder.HasOne(bl => bl.BookCopy)
+                    .WithMany(b => b.BookLoans)
+                    .HasForeignKey(bl => bl.BookCopyId);
+
+            builder.HasOne(bl => bl.Member)
+                    .WithMany(m => m.BookLoans)
+                    .HasForeignKey(bl => bl.MemberId);
+
+
+        }
+    }
+}

--- a/LibraryApp.Domain/Entities/Configurations/MemberConfiguration.cs
+++ b/LibraryApp.Domain/Entities/Configurations/MemberConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LibraryApp.Domain.Entities.Configurations;
+
+public class MemberConfiguration:BaseUserConfiguration<Member>
+{
+    public override void Configure(EntityTypeBuilder<Member> builder)
+    {
+        base.Configure(builder);
+        builder.Property(m => m.MembershipNumber)
+                                .HasMaxLength(50)
+                                .IsRequired();
+
+        // Navigation property: A member can borrow more than one book
+        builder.HasMany(m => m.BookLoans)
+               .WithOne(bl => bl.Member)
+               .HasForeignKey(bl => bl.MemberId)
+               .OnDelete(DeleteBehavior.Restrict);
+
+    }
+}

--- a/LibraryApp.Domain/Entities/DbSets/Book.cs
+++ b/LibraryApp.Domain/Entities/DbSets/Book.cs
@@ -9,12 +9,11 @@ public class Book : AuditableEntity
     public string? Description { get; set; }
     public string Author { get; set; } = null!;
     public DateTime PublicationYear { get; set; }
-    public BookStatus BookStatus { get; set; }
 
     // Nav Props
 
     public Guid BookCategoryId { get; set; }
     public virtual BookCategory BookCategory { get; set; } = null!;
-    public virtual ICollection<BookLoan>? BookLoans { get; set; }
+    public virtual ICollection<BookCopy>? BookCopies { get; set; }
 
 }

--- a/LibraryApp.Domain/Entities/DbSets/BookCopy.cs
+++ b/LibraryApp.Domain/Entities/DbSets/BookCopy.cs
@@ -1,0 +1,15 @@
+﻿using LibraryApp.Domain.Entities.Enums;
+
+namespace LibraryApp.Domain.Entities.DbSets;
+
+public class BookCopy:AuditableEntity
+{
+    public string CopyNumber { get; set; } = null!;
+    public BookStatus BookStatus { get; set; }
+
+    // Nav Props
+    public Guid BookId { get; set; }
+    public virtual Book Book { get; set; } = null!;
+
+    public virtual ICollection<BookLoan>? BookLoans { get; set; }
+}

--- a/LibraryApp.Domain/Entities/DbSets/BookLoan.cs
+++ b/LibraryApp.Domain/Entities/DbSets/BookLoan.cs
@@ -6,8 +6,8 @@ public class BookLoan : AuditableEntity
     public DateTime? ReturnDate { get; set; }
 
     // Nav props
-    public Guid BookId { get; set; }
-    public virtual Book? Book { get; set; }
+    public Guid BookCopyId { get; set; }
+    public virtual BookCopy BookCopy { get; set; } = null!;
     public Guid MemberId { get; set; }
     public virtual Member? Member { get; set; }
 }

--- a/LibraryApp.Domain/GlobalUsings.cs
+++ b/LibraryApp.Domain/GlobalUsings.cs
@@ -2,4 +2,6 @@
 global using LibraryApp.Domain.Core.Enums;
 global using LibraryApp.Domain.Core.Entities.Interfaces;
 global using LibraryApp.Domain.Core.Entities.Base;
+global using BAExamApp.Core.Entities.EntityTypeConfigurations;
+global using LibraryApp.Domain.Entities.DbSets;
 

--- a/LibraryApp.sln
+++ b/LibraryApp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35825.156 d17.13
+VisualStudioVersion = 17.13.35825.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryApp.Domain", "LibraryApp.Domain\LibraryApp.Domain.csproj", "{3CB628BB-9F5A-454E-9555-86A14B529D87}"
 EndProject


### PR DESCRIPTION
Updated the `Book` class to use `BookCopies` instead of `BookLoans`, introducing the `BookCopy` class to represent individual book copies. Updated the `BookLoan` class to reference `BookCopy`.

Added new configuration classes for `Book`, `BookCopy`, `BookLoan`, `Member`, and `Admin` to define entity configurations using Entity Framework Core's Fluent API.