### PR TITLE
Update project structure and repository interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,4 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-/LibraryApp.Presentation/appsettings.Development.json
+

--- a/LibraryApp.DataAccess/Interfaces/IAdminRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IAdminRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IAdminRepository : IAsyncRepository,
+                                    IAsyncFindableRepository<Admin>,
+                                    IAsyncInsertableRepository<Admin>,
+                                    IAsyncDeletableRepository<Admin>,
+                                    IAsyncUpdatableRepository<Admin>,
+                                    IAsyncTransactionRepository
+{
+    Task<Admin?> GetByIdentityIdAsync(string identityId);
+}

--- a/LibraryApp.DataAccess/Interfaces/IBookCategoryRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IBookCategoryRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IBookCategoryRepository :        IAsyncRepository,
+                                        IAsyncInsertableRepository<BookCategory>,
+                                        IAsyncUpdatableRepository<BookCategory>,
+                                        IAsyncDeletableRepository<BookCategory>,
+                                        IAsyncFindableRepository<BookCategory>,
+                                        IAsyncQueryableRepository<BookCategory>,
+                                        IAsyncOrderableRepository<BookCategory>
+{
+}

--- a/LibraryApp.DataAccess/Interfaces/IBookCopyRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IBookCopyRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IBookCopyRepository :        IAsyncRepository,
+                                    IAsyncInsertableRepository<BookCopy>,
+                                    IAsyncUpdatableRepository<BookCopy>,
+                                    IAsyncDeletableRepository<BookCopy>,
+                                    IAsyncFindableRepository<BookCopy>,
+                                    IAsyncQueryableRepository<BookCopy>,
+                                    IAsyncOrderableRepository<BookCopy>
+{
+}

--- a/LibraryApp.DataAccess/Interfaces/IBookLoanRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IBookLoanRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IBookLoanRepository : IAsyncRepository,
+                                    IAsyncInsertableRepository<BookLoan>,
+                                    IAsyncUpdatableRepository<BookLoan>,
+                                    IAsyncDeletableRepository<BookLoan>,
+                                    IAsyncFindableRepository<BookLoan>,
+                                    IAsyncQueryableRepository<BookLoan>,
+                                    IAsyncOrderableRepository<BookLoan>
+{
+}

--- a/LibraryApp.DataAccess/Interfaces/IBookRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IBookRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IBookRepository:   IAsyncRepository, 
+                                    IAsyncInsertableRepository<Book>,
+                                    IAsyncUpdatableRepository<Book>,
+                                    IAsyncDeletableRepository<Book>,
+                                    IAsyncFindableRepository<Book>,
+                                    IAsyncQueryableRepository<Book>,
+                                    IAsyncOrderableRepository<Book>
+{
+}

--- a/LibraryApp.DataAccess/Interfaces/IMemberRepository.cs
+++ b/LibraryApp.DataAccess/Interfaces/IMemberRepository.cs
@@ -1,0 +1,14 @@
+﻿using LibraryApp.Domain.Core.DataAccess.Interfaces;
+using LibraryApp.Domain.Entities.DbSets;
+
+namespace LibraryApp.DataAccess.Interfaces;
+
+public interface IMemberRepository : IAsyncRepository, 
+                                    IAsyncFindableRepository<Member>, 
+                                    IAsyncInsertableRepository<Member>, 
+                                    IAsyncDeletableRepository<Member>, 
+                                    IAsyncUpdatableRepository<Member>, 
+                                    IAsyncTransactionRepository
+{
+    Task<Member?> GetByIdentityIdAsync(string identityId);
+}

--- a/LibraryApp.DataAccess/LibraryApp.DataAccess.csproj
+++ b/LibraryApp.DataAccess/LibraryApp.DataAccess.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LibraryApp.Domain\LibraryApp.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/LibraryApp.Domain/Core/DataAccess/EntityFramework/EFBaseRepository.cs
+++ b/LibraryApp.Domain/Core/DataAccess/EntityFramework/EFBaseRepository.cs
@@ -14,8 +14,8 @@ public abstract class EFBaseRepository<TEntity> : IAsyncOrderableRepository<TEnt
                                                  IAsyncFindableRepository<TEntity>,
                                                  IAsyncQueryableRepository<TEntity>,
                                                  IAsyncInsertableRepository<TEntity>,
-                                                 IAsyncUpdateableRepository<TEntity>,
-                                                 IAsyncDeleteableRepository<TEntity>,
+                                                 IAsyncUpdatableRepository<TEntity>,
+                                                 IAsyncDeletableRepository<TEntity>,
                                                  IAsyncRepository,
                                                  IAsyncTransactionRepository,
                                                  IRepository

--- a/LibraryApp.Domain/Core/DataAccess/Interfaces/IAsyncDeletableRepository.cs
+++ b/LibraryApp.Domain/Core/DataAccess/Interfaces/IAsyncDeletableRepository.cs
@@ -1,6 +1,6 @@
 ﻿namespace LibraryApp.Domain.Core.DataAccess.Interfaces;
 
-public interface IAsyncDeleteableRepository<TEntity> : IAsyncRepository where TEntity : BaseEntity
+public interface IAsyncDeletableRepository<TEntity> : IAsyncRepository where TEntity : BaseEntity
 {
     Task DeleteAsync(TEntity entity);
     Task DeleteRangeAsync(IEnumerable<TEntity> entities);

--- a/LibraryApp.Domain/Core/DataAccess/Interfaces/IAsyncUpdatableRepository.cs
+++ b/LibraryApp.Domain/Core/DataAccess/Interfaces/IAsyncUpdatableRepository.cs
@@ -1,6 +1,6 @@
 ﻿namespace LibraryApp.Domain.Core.DataAccess.Interfaces;
 
-public interface IAsyncUpdateableRepository<TEntity> : IAsyncRepository where TEntity : BaseEntity
+public interface IAsyncUpdatableRepository<TEntity> : IAsyncRepository where TEntity : BaseEntity
 {
     Task<TEntity> UpdateAsync(TEntity entity);
 }

--- a/LibraryApp.Presentation/appsettings.Development.json
+++ b/LibraryApp.Presentation/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "AppConnectionDev": "Server = AKS\\SQLEXPRESS; Database=LibraryProject; Trusted_Connection=True; Encrypt = True; TrustServerCertificate=True"
+  }
+}


### PR DESCRIPTION
- Updated `.gitignore` to include `MigrationBackup/` and remove `appsettings.Development.json`.
- Modified `LibraryApp.DataAccess.csproj` to reference `LibraryApp.Domain.csproj` and target `net9.0`.
- Renamed interfaces in `EFBaseRepository.cs` for consistency.
- Redefined `IAsyncDeleteableRepository` and `IAsyncUpdateableRepository` to include relevant methods.
- Created new repository interfaces for various entities to support CRUD operations.
- Added `appsettings.Development.json` with logging configuration and connection string.